### PR TITLE
Опциональная установка SendCityCode и RecCityCode

### DIFF
--- a/src/Common/Order.php
+++ b/src/Common/Order.php
@@ -449,7 +449,7 @@ class Order
      */
     public function getSendCityCode(): ?int
     {
-        return $this->SendCity ? $this->SendCity->getCode() : null;
+        return $this->SendCity ? $this->SendCity->getCode() ?: null : null;
     }
 
     /**
@@ -475,7 +475,7 @@ class Order
      */
     public function getRecCityCode(): ?int
     {
-        return $this->RecCity ? $this->RecCity->getCode() : null;
+        return $this->RecCity ? $this->RecCity->getCode() ?: null : null;
     }
 
     /**

--- a/src/Common/Order.php
+++ b/src/Common/Order.php
@@ -449,7 +449,7 @@ class Order
      */
     public function getSendCityCode(): ?int
     {
-        return $this->SendCity ? $this->SendCity->getCode() ?: null : null;
+        return $this->SendCity ? ($this->SendCity->getCode() ?: null) : null;
     }
 
     /**
@@ -475,7 +475,7 @@ class Order
      */
     public function getRecCityCode(): ?int
     {
-        return $this->RecCity ? $this->RecCity->getCode() ?: null : null;
+        return $this->RecCity ? ($this->RecCity->getCode() ?: null) : null;
     }
 
     /**


### PR DESCRIPTION
Добавлена возможность указать SendCityCode и RecCityCode равными null, посредством установки cвойства Code модели City равного 0. Т.к. API СДЭК устанавливает данные параметры как необязательные, а справочник городов СДЭК представлен не в очень удобной форме - таблицах Excel - в реальной жизни в большинстве случаев удобно указать только почтовый индекс городов отправления и получения.