### PR TITLE
Опциональная установка свойства Code модели City

### DIFF
--- a/src/Common/City.php
+++ b/src/Common/City.php
@@ -46,7 +46,7 @@ class City
      */
     protected $Name;
 
-    public function getCode(): int
+    public function getCode(): ?int
     {
         return $this->Code;
     }


### PR DESCRIPTION
Добавлена возможность установки cвойства Code модели City равного null. Т.к. API СДЭК устанавливает данные параметры как необязательные, а справочник городов СДЭК представлен не в очень удобной форме - таблицах Excel - в реальной жизни в большинстве случаев удобно указать только почтовый индекс городов отправления и получения.