### PR TITLE
Add phpdoc return type for PvzListResponse->getItems()

### DIFF
--- a/src/Responses/PvzListResponse.php
+++ b/src/Responses/PvzListResponse.php
@@ -31,6 +31,9 @@ class PvzListResponse
      */
     private $items = [];
 
+    /**
+     * @return Pvz[]
+     */
     public function getItems(): array
     {
         return $this->items;


### PR DESCRIPTION
PhpStorm for some reason won't get that type from `$items` property.