### PR TITLE
Поддержка дополнительных услуг в калькуляторе (fixes #13)

### DIFF
--- a/src/Requests/CalculationRequest.php
+++ b/src/Requests/CalculationRequest.php
@@ -25,12 +25,24 @@ class CalculationRequest implements JsonRequest
 {
     use RequestCore;
 
-    public const MODE_DOOR_DOOR = 1;
-    public const MODE_DOOR_WAREHOUSE = 2;
-    public const MODE_WAREHOUSE_DOOR = 3;
+    public const SERVICE_INSURANCE         = 2;  // Страховка
+    public const SERVICE_HAZARDOUS_CARGO   = 7;  // Опасный груз
+    public const SERVICE_PICKUP            = 16; // Забор в городе отправителе
+    public const SERVICE_DELIVERY_TO_DOOR  = 17; // Доставка в городе получателе
+    public const SERVICE_PACKAGE_1         = 24; // Упаковка 1
+    public const SERVICE_PACKAGE_2         = 25; // Упаковка 2
+    public const SERVICE_FITTING_AT_HOME   = 30; // Примерка на дому
+    public const SERVICE_PERSONAL_DELIVERY = 31; // Доставка лично в руки
+    public const SERVICE_DOCUMENTS_COPY    = 32; // Скан документов
+    public const SERVICE_PARTIAL_DELIVERY  = 36; // Частичная доставка
+    public const SERVICE_CARGO_CHECK       = 37; // Осмотр вложения
+
+    public const MODE_DOOR_DOOR           = 1;
+    public const MODE_DOOR_WAREHOUSE      = 2;
+    public const MODE_WAREHOUSE_DOOR      = 3;
     public const MODE_WAREHOUSE_WAREHOUSE = 4;
 
-    protected const METHOD = 'POST';
+    protected const METHOD  = 'POST';
     protected const ADDRESS = 'https://api.cdek.ru/calculator/calculate_price_by_json.php';
 
     protected $senderCityId;
@@ -38,6 +50,7 @@ class CalculationRequest implements JsonRequest
 
     protected $goods;
     protected $modeId;
+    protected $services;
     protected $tariffId;
     protected $tariffList = [];
     protected $receiverCityId;
@@ -108,6 +121,14 @@ class CalculationRequest implements JsonRequest
         return $this;
     }
 
+    public function addAdditionalService($serviceId, $param = null)
+    {
+        $this->services[] = [
+            'id'    => $serviceId,
+            'param' => $param,
+        ];
+    }
+
     public function getBody(): array
     {
         return array_filter([
@@ -118,6 +139,7 @@ class CalculationRequest implements JsonRequest
             'tariffList'           => $this->tariffList,
             'senderCityId'         => $this->senderCityId,
             'senderCityPostCode'   => $this->senderCityPostCode,
+            'services'             => $this->services,
             'receiverCityId'       => $this->receiverCityId,
             'receiverCityPostCode' => $this->receiverCityPostCode,
         ]);

--- a/src/Requests/CalculationRequest.php
+++ b/src/Requests/CalculationRequest.php
@@ -127,6 +127,8 @@ class CalculationRequest implements JsonRequest
             'id'    => $serviceId,
             'param' => $param,
         ];
+
+        return $this;
     }
 
     public function getBody(): array

--- a/src/Responses/Types/Result.php
+++ b/src/Responses/Types/Result.php
@@ -132,7 +132,7 @@ class Result
     /**
      * @return array|null
      */
-    public function getServices(): ?array
+    public function getAdditionalServices(): ?array
     {
         return $this->services;
     }

--- a/src/Responses/Types/Result.php
+++ b/src/Responses/Types/Result.php
@@ -81,6 +81,14 @@ class Result
      */
     protected $currency;
 
+    /**
+     * @JMS\SerializedName("services")
+     * @JMS\Type("array")
+     *
+     * @var null|array
+     */
+    protected $services;
+
     public function getPrice(): ?float
     {
         return $this->price;
@@ -119,5 +127,13 @@ class Result
     public function getDeliveryDateMax(): ?\DateTimeImmutable
     {
         return $this->deliveryDateMax;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getServices(): ?array
+    {
+        return $this->services;
     }
 }


### PR DESCRIPTION
Собственно, написал поддержку дополнительных услуг (см. #13). В `Result` не получилось заюзать уже имеющийся `AdditionalServices`, т.к. у него там совсем другая структура и он вообще для xml запросов, массив услуг при вызове `getServices()` возвращается как есть, в виде многоменрого массива. Если считаете что нужно это как-то превращать во некий массив объектов, то велкам доделать это.

Также добавил константы для кодов доступных дополнительных услуг.

Проверил на добавлении услуги страховки, вроде всё корректно.